### PR TITLE
fix(form-login-2): 配置 successForwardUrl 出现 405 异常

### DIFF
--- a/form-login-2/src/main/java/org/javaboy/formlogin/HelloController.java
+++ b/form-login-2/src/main/java/org/javaboy/formlogin/HelloController.java
@@ -36,4 +36,9 @@ public class HelloController {
     public String f2() {
         return "f2";
     }
+
+    @RequestMapping("/index")
+    public String index(){
+        return "index";
+    }
 }

--- a/form-login-2/src/main/java/org/javaboy/formlogin/SecurityConfig.java
+++ b/form-login-2/src/main/java/org/javaboy/formlogin/SecurityConfig.java
@@ -46,7 +46,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .loginProcessingUrl("/doLogin")
                 .usernameParameter("name")
                 .passwordParameter("passwd")
+                // defaultSuccessUrl 是重定向，浏览器地址会变
                 .defaultSuccessUrl("/index")
+                //successForwardUrl 和 defaultSuccessUrl 一起配置时，successForwardUrl 生效
+                //successForwardUrl 是转发,浏览器地址仍为登录请求地址，因此 url "/index" 要支持 POST 请求才可以转发成功，否则会有405异常
                 .successForwardUrl("/index")
                 .failureForwardUrl("/f2")
                 .failureUrl("/f1")


### PR DESCRIPTION
hi, 松哥，这篇文章[手把手教你定制 Spring Security 中的表单登录](https://mp.weixin.qq.com/s/kHJRKwH-WUx-JEeaQMa7jw) 关于 登录成功回调方法 successForwardUrl 的描述有点问题哈。经过搜索得出结论：successForwardUrl 会将请求转发到配置的地址，由于登录是POST 请求，并且 Spring MVC 不支持 POST 请求返回页面，因此会报错 405。所以在示例代码里，加了一个 “/index" url 请求处理的方法，解决这个问题。